### PR TITLE
Make libtiff release-agnostic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     - libopencv-dev
     - libqt4-dev
     - libswscale-dev
-    - libtiff4-dev
+    - libtiff-dev
     - ocl-icd-opencl-dev
     - pkg-config
     - python-numpy


### PR DESCRIPTION
This solves the issue of libtiff4 not being available under xenial.

Using the alias will allow the package to be installed under both
trusty and xenial.