### PR TITLE
Add missing python-dev apt dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
     - libtiff-dev
     - ocl-icd-opencl-dev
     - pkg-config
+    - python-dev
     - python-numpy
     - unzip
     - yasm


### PR DESCRIPTION
Without it, the `python2` build target won't be available, and no python bindings will be produced (the cv2.so file).